### PR TITLE
Avoid segfault from empty 'Open' dialog

### DIFF
--- a/session-manager/src/session-manager.C
+++ b/session-manager/src/session-manager.C
@@ -585,7 +585,7 @@ public:
             {
                 const char *name = fl_input( "Open Session", NULL );
                 
-                if ( ! name )
+                if ( ! name || *name == '\0' )
                     return;
                 
                 Fl_Tree_Item *item = session_browser->find_item( name );


### PR DESCRIPTION
Fl_Tree::find_item() segfaults when called with an empty string. This
may be an NTK/FLTK problem, but this will fix things in the meantime.
