### PR TITLE
Prevent crash when trying to add Aux before input

### DIFF
--- a/mixer/src/Module.C
+++ b/mixer/src/Module.C
@@ -808,6 +808,13 @@ Module::insert_menu_cb ( const Fl_Menu_ *m )
     
     if ( !strcmp( picked, "Aux" ) )
     {
+
+        if ( ninputs() == 0 )
+        {
+            fl_alert( "Cannot insert this module at this point in the chain" );
+            return;
+        }
+
         int n = 0;
         for ( int i = 0; i < chain()->modules(); i++ )
         {


### PR DESCRIPTION
Hi @original-male :-)

As I was trying to hack OSC control for number of JACK ports per strip into non-mixer, I noticed a segfault when trying to add an Aux before the JACK input. Decided to have a go at preventing it, and, well, here's my fix. :-)

Now these are just my baby steps in C++, so let me know if there's a better solution. No currently available module looks like it'd make any sense to put it before a track strip's JACK input, so maybe this check needs to be done right at the start. No other module seemed to crash though (the actual cause of the problem was a division by zero in `AUX_Module::draw`) so I've left it like this.

I still haven't figured out if the index of the right-clicked module is easily available in the menu handler so that I could hide the entire "insert" menu when clicking on the first module in the chain, or else make any new modules chain after, rather than before, the input.
