### PR TITLE
Fix crash when adding non-notes to event editor

### DIFF
--- a/sequencer/src/gui/event_edit.fl
+++ b/sequencer/src/gui/event_edit.fl
@@ -138,7 +138,7 @@ else
 		
 	e->status( opcode );
 
-	Event_Widget *ew = v->value();
+	Event_Widget *ew;
 
 	if ( ew && ew->ev() )
 		e->timestamp( ew->ev()->timestamp() );


### PR DESCRIPTION
Applied fix as mentioned here by @nico202 https://github.com/original-male/non/issues/182

Fixes https://github.com/original-male/non/issues/182 and https://github.com/original-male/non/issues/118
